### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -105,6 +105,7 @@ class CheckoutController extends Controller
             }
         }
 
-        return response('[accepted]', 200);
+        // Set the status code to 202 and return an empty response body
+        return response()->noContent()->setStatusCode(202);
     }
 }


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.