### PR TITLE
Change base image to bitnamilegacy/laravel:9.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM bitnami/laravel:9.1.7
+FROM bitnamilegacy/laravel:9.1.7
 
 RUN apt-get update -y && apt-get install -y libmcrypt-dev
 


### PR DESCRIPTION
All existing Bitnami container image have been moved to the [Bitnami Legacy repository](https://hub.docker.com/u/bitnamilegacy). This has affected the PHP sample app, breaking the CI/CD pipeline.

This PR updates the Dockerfile to correct the location of the Docker base image.